### PR TITLE
Баф м44 револьвера. (магнум каким он должен быть)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -561,8 +561,8 @@
 	name = "revolver bullet"
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 
-	damage = 55
-	penetration = ARMOR_PENETRATION_TIER_1
+	damage = 75
+	penetration = ARMOR_PENETRATION_TIER_3
 	accuracy = HIT_ACCURACY_TIER_1
 
 /datum/ammo/bullet/revolver/marksman
@@ -576,7 +576,7 @@
 /datum/ammo/bullet/revolver/heavy
 	name = "heavy revolver bullet"
 
-	damage = 35
+	damage = 45
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
 


### PR DESCRIPTION
В кратце: 
Баф м44 револьвера, а если быть точнее - его пуль.

Почему?:

Потому что револьвер очень слабый и не конкурентноспособный с модом 88 и м4а3, это мертвая пушка, которую нужно воскрешать. Да и в целом если посмотреть - это 44 магнум, калибр очень серьезный и патрон крайне мощный.

Изменения: 
Обычные пули: урон 55 -> 75, АП 5 -> 15.
марксман: патроны: урон 55 -> 75.
хеви патроны: урон 35 ->45.

:cl:
balance: Повышен урон револьвера.
/:cl:
