### PR TITLE
фиксы ксеноботиков в 3 часа ночи

### DIFF
--- a/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -96,13 +96,10 @@
 	if (evaluate_embryo_existance(target))
 		return FALSE
 
-	if (issynth(target))
+	if (issynth(target) || ismonkey(target) || target.alpha < 50)
 		return FALSE
 
 	if (target.pulledby && isxeno(target.pulledby))
-		return FALSE
-
-	if (target.alpha < 50)
 		return FALSE
 
 	return target

--- a/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -33,6 +33,10 @@
 
 	var/special_attack_probability = XENO_AI_SPECIAL_ATTACK_PROBABILITY
 
+/mob/living/simple_animal/hostile/alien/spawnable/New()
+	. = ..()
+	target_mob = FindTarget()
+
 /mob/living/simple_animal/hostile/alien/spawnable/generate_name()
 	change_real_name(src, "\improper[caste_name] (WT-[rand(1, 999)])")
 
@@ -125,6 +129,7 @@
 		return 1
 
 /mob/living/simple_animal/hostile/alien/spawnable/AttackingTarget()
+	face_atom(target_mob)
 	if(!Adjacent(target_mob))
 		return
 	if(isliving(target_mob))
@@ -134,7 +139,6 @@
 		L.attack_animal(src)
 		src.animation_attack_on(L)
 		src.flick_attack_overlay(L, "slash")
-		playsound(src.loc, "alien_claw_flesh", 25, 1)
 		return L
 
 /mob/living/simple_animal/hostile/alien/spawnable/proc/evaluate_special_attack(mob/living/L)
@@ -175,6 +179,16 @@
 	SEND_SIGNAL(P, COMSIG_BULLET_ACT_XENO, src, damage, damage_result)
 
 	return TRUE
+
+/mob/living/simple_animal/hostile/alien/spawnable/apply_damage()
+	. = ..()
+	if(stance == HOSTILE_STANCE_IDLE)
+		target_mob = FindTarget()
+
+/mob/living/simple_animal/hostile/alien/spawnable/updatehealth()
+	. = ..()
+	if(health < 1)
+		death()
 
 /mob/living/simple_animal/hostile/alien/spawnable/death(cause, gibbed, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw. The caustic acid starts melting the body away...")
 	. = ..()

--- a/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/fray-marines/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -180,7 +180,7 @@
 
 	return TRUE
 
-/mob/living/simple_animal/hostile/alien/spawnable/apply_damage()
+/mob/living/simple_animal/hostile/alien/spawnable/apply_damage(damage, damagetype, def_zone, used_weapon, sharp, edge, force)
 	. = ..()
 	if(stance == HOSTILE_STANCE_IDLE)
 		target_mob = FindTarget()


### PR DESCRIPTION
:cl:
fix: УРА УРА ксеноботы умирают когда кончается здоровье, а не в 3-и часа ночи каждой пятницы 9-й недели високосного года по китайскому календарю.
fix: Ксеноботы больше не выдают двойного звука удара когтями.
fix: Ксеноботы теперь практически не тупят перед морпехами.
fix: Ксеноботы стали смотреть на врага во время атаки.
fix: Ксеноботы прекратили бить безобидных обезьян.
/:cl:
