### PR TITLE
Fix TOW ammo req

### DIFF
--- a/code/datums/supply_packs/vehicle_ammo.dm
+++ b/code/datums/supply_packs/vehicle_ammo.dm
@@ -109,7 +109,10 @@
 
 /datum/supply_packs/ammo_towlauncher
 	name = "TOW Launcher magazines (x3)"
-	contains = list(/obj/item/hardpoint/secondary/towlauncher)
+	contains = list(
+		/obj/item/ammo_magazine/hardpoint/towlauncher,
+		/obj/item/ammo_magazine/hardpoint/towlauncher,
+		/obj/item/ammo_magazine/hardpoint/towlauncher)
 	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "TOW launcher ammo crate"

--- a/code/datums/supply_packs/vehicle_ammo.dm
+++ b/code/datums/supply_packs/vehicle_ammo.dm
@@ -112,7 +112,7 @@
 	contains = list(
 		/obj/item/ammo_magazine/hardpoint/towlauncher,
 		/obj/item/ammo_magazine/hardpoint/towlauncher,
-		/obj/item/ammo_magazine/hardpoint/towlauncher
+		/obj/item/ammo_magazine/hardpoint/towlauncher,
 	)
 	cost = 30
 	containertype = /obj/structure/closet/crate/ammo

--- a/code/datums/supply_packs/vehicle_ammo.dm
+++ b/code/datums/supply_packs/vehicle_ammo.dm
@@ -112,7 +112,8 @@
 	contains = list(
 		/obj/item/ammo_magazine/hardpoint/towlauncher,
 		/obj/item/ammo_magazine/hardpoint/towlauncher,
-		/obj/item/ammo_magazine/hardpoint/towlauncher)
+		/obj/item/ammo_magazine/hardpoint/towlauncher
+	)
 	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "TOW launcher ammo crate"


### PR DESCRIPTION

# About the pull request

Заказываемый TOW Launcher magazines (x3) теперь содержит в себе не саму TOW, а 3 магазина к ней.

# Changelog
:cl:
fix: Заказываемый TOW Launcher magazines (x3) теперь содержит в себе не саму TOW, а 3 магазина к ней.
/:cl:
