### PR TITLE
Попытка пофиксить """Фоторужьё""" [готово к мержу]

### DIFF
--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -402,8 +402,8 @@
 		/obj/item/storage/pouch/cassette = 15,
 		/obj/item/toy/deck = 5,
 		/obj/item/toy/deck/uno = 5,
-		/obj/item/device/camera = 5,
-		/obj/item/device/camera_film = 10,
+//		/obj/item/device/camera = 5, LAG MACHINE
+//		/obj/item/device/camera_film = 10,
 		/obj/item/notepad = 5,
 	)
 
@@ -418,6 +418,6 @@
 		/obj/item/storage/pouch/cassette = 10,
 		/obj/item/toy/deck = 20,
 		/obj/item/toy/deck/uno = 15,
-		/obj/item/device/camera = 30,
+//		/obj/item/device/camera = 30,
 	)
 	product_type = VENDOR_PRODUCT_TYPE_RECREATIONAL

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -67,7 +67,6 @@
 		/datum/action/xeno_action/activable/burrow, //third macro
 		/datum/action/xeno_action/onclick/tremor, //fourth macro
 		/datum/action/xeno_action/onclick/tacmap,
-		/datum/action/xeno_action/onclick/build_lessers_burrow,
 		)
 
 	inherent_verbs = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -64,7 +64,6 @@
 		/datum/action/xeno_action/activable/secrete_resin, //third macro
 		/datum/action/xeno_action/activable/transfer_plasma, //fourth macro
 		/datum/action/xeno_action/onclick/tacmap,
-		/datum/action/xeno_action/onclick/build_lessers_burrow,
 		)
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -69,7 +69,6 @@
 		/datum/action/xeno_action/activable/transfer_plasma/hivelord, // to be consistent with drone placement
 		/datum/action/xeno_action/active_toggle/toggle_speed, //fourth macro
 		/datum/action/xeno_action/onclick/tacmap,
-		/datum/action/xeno_action/onclick/build_lessers_burrow,
 		)
 
 	inherent_verbs = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -303,7 +303,6 @@
 		/datum/action/xeno_action/onclick/readmit,
 		/datum/action/xeno_action/onclick/queen_award,
 		/datum/action/xeno_action/activable/info_marker/queen,
-		/datum/action/xeno_action/onclick/build_lessers_burrow,
 	)
 
 	inherent_verbs = list(
@@ -340,7 +339,6 @@
 		/datum/action/xeno_action/onclick/screech, //custom macro, Screech
 		/datum/action/xeno_action/activable/xeno_spit/queen_macro, //third macro
 		/datum/action/xeno_action/onclick/shift_spits, //second macro
-		/datum/action/xeno_action/onclick/build_lessers_burrow,
 	)
 
 	// Abilities they get when they've successfully aged.

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -259,9 +259,15 @@
 /obj/item/device/camera/proc/captureimage(atom/target, mob/user, flag)
 	var/mobs = ""
 	var/radius = (size-1)*0.5
+	var/max_mobs_desc = 4
 	var/list/turf/turfs = RANGE_TURFS(radius, target) & view(world_view_size + radius, user.client)
 	for(var/turf/T as anything in turfs)
-		mobs += get_mobs(T)
+		if(!max_mobs_desc)
+			break
+		var/mob = get_mobs(T)
+		if(mob)
+			mobs += mob
+			max_mobs_desc--
 	var/datum/picture/P = createpicture(target, user, turfs, mobs, flag)
 	printpicture(user, P)
 


### PR DESCRIPTION
:cl:
fix: Удалось снизить лаг от фотографирования людей посредствам ограничения максимальной длины описания фото.
del: Фотоаппарат и его картриджи более нельзя купить в вендомате W-Y.
del: Убрал способность строительным кастам делать дырки ботоксен.
/:cl:

![image](https://github.com/Fray2/RU-CMSS13/assets/65656972/3e3eab88-9167-4ebb-9569-6f0b205095cf)

> Да, у фото существует механ описания. Мало того - там пишется имя фамилия КАЖДОГО человека с фотографии, потом пишется что тот держит, и на последок отпечатывает как сильно он отпизжен в кадре. Ещё и с кучей прожорливых проверок. Теперь в описание влезает не больше четырёх людей с фото!